### PR TITLE
wpebackend: Bump to 0.2.0

### DIFF
--- a/recipes-browser/wpebackend/wpebackend_0.1.bb
+++ b/recipes-browser/wpebackend/wpebackend_0.1.bb
@@ -1,7 +1,0 @@
-require wpebackend.inc
-
-SRC_URI = "https://wpewebkit.org/releases/${PN}-${PV}.tar.xz"
-SRC_URI[md5sum] = "0c4bba4dec2044f087fa119b456a893e"
-SRC_URI[sha256sum] = "12261b5819ce64c0eb2b065d9cc2c201c77ddf8bfad31bd8d4e369ce9365ad21"
-
-S = "${WORKDIR}/${PN}-${PV}"

--- a/recipes-browser/wpebackend/wpebackend_0.2.0.bb
+++ b/recipes-browser/wpebackend/wpebackend_0.2.0.bb
@@ -1,0 +1,7 @@
+require wpebackend.inc
+
+SRC_URI = "https://wpewebkit.org/releases/${PN}-${PV}.tar.xz"
+SRC_URI[md5sum] = "d04e44a32709dbb763ce1fcfc28bc6d8"
+SRC_URI[sha256sum] = "ce33ff29b04175cb6fe6e6597a4b5e8ec9da0b8b5ae0745848902ac935d65823"
+
+S = "${WORKDIR}/${PN}-${PV}"


### PR DESCRIPTION
wpebackend version 0.2.0 was also released. It may be useful for those
who do wish to use the stable version of wpewebkit (for example due to using
wpebackend-rdk).

Signed-off-by: Maciej Pijanowski <maciej.pijanowski@3mdeb.com>

@philn It feels to me like it should be a part of your PR which bumps all the recipes.
Let me know if you think it should be a separate PR. Thanks.